### PR TITLE
카카오 로그인 API 인증 구현 완료 #1

### DIFF
--- a/backend/database/populmap.sql
+++ b/backend/database/populmap.sql
@@ -1,0 +1,114 @@
+-- MySQL dump 10.13  Distrib 8.0.30, for macos12.4 (arm64)
+--
+-- Host: 127.0.0.1    Database: populmap
+-- ------------------------------------------------------
+-- Server version	5.5.5-10.3.36-MariaDB-0+deb10u2
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `auth_site`
+--
+
+DROP TABLE IF EXISTS `auth_site`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `auth_site` (
+  `site_id` int(11) NOT NULL AUTO_INCREMENT,
+  `site_user_id` int(11) NOT NULL,
+  `password` varchar(32) NOT NULL,
+  `first_login` datetime DEFAULT NULL,
+  `last_login` datetime DEFAULT NULL,
+  PRIMARY KEY (`site_id`),
+  UNIQUE KEY `site_user_id` (`site_user_id`),
+  CONSTRAINT `site_user_id` FOREIGN KEY (`site_user_id`) REFERENCES `user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `auth_site`
+--
+
+LOCK TABLES `auth_site` WRITE;
+/*!40000 ALTER TABLE `auth_site` DISABLE KEYS */;
+/*!40000 ALTER TABLE `auth_site` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `auth_social`
+--
+
+DROP TABLE IF EXISTS `auth_social`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `auth_social` (
+  `social_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL COMMENT 'user의 fk',
+  `social_user_id` bigint DEFAULT NULL,
+  `social_type` varchar(16) NOT NULL,
+  `access_token` varchar(256) NOT NULL,
+  `first_login` datetime DEFAULT NULL,
+  `last_login` datetime DEFAULT NULL,
+  PRIMARY KEY (`social_id`),
+  UNIQUE KEY `access_token` (`access_token`),
+  UNIQUE KEY `user_id` (`user_id`),
+  UNIQUE KEY `social_id` (`social_id`),
+  CONSTRAINT `user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `auth_social`
+--
+
+LOCK TABLES `auth_social` WRITE;
+/*!40000 ALTER TABLE `auth_social` DISABLE KEYS */;
+/*!40000 ALTER TABLE `auth_social` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `user`
+--
+
+DROP TABLE IF EXISTS `user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `user` (
+  `user_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_name` varchar(64) NOT NULL,
+  `email` varchar(64) NOT NULL,
+  `login_type` varchar(16) NOT NULL,
+  PRIMARY KEY (`user_id`),
+  UNIQUE KEY `email` (`email`),
+  UNIQUE KEY `user_name` (`user_name`)
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `user`
+--
+
+LOCK TABLES `user` WRITE;
+/*!40000 ALTER TABLE `user` DISABLE KEYS */;
+/*!40000 ALTER TABLE `user` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2022-11-15 14:43:42

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^1.0.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^2.2.0",
         "@nestjs/core": "^9.0.0",
@@ -16,14 +17,20 @@
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/typeorm": "^9.0.1",
+        "@types/cookie-parser": "^1.4.3",
+        "@types/passport-jwt": "^3.0.7",
         "@types/passport-kakao": "^1.0.0",
+        "@types/uuid": "^8.3.4",
+        "cookie-parser": "^1.4.6",
         "mysql": "^2.18.1",
         "passport": "^0.6.0",
+        "passport-jwt": "^4.0.0",
         "passport-kakao": "^1.0.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
-        "typeorm": "^0.3.10"
+        "typeorm": "^0.3.10",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^9.0.0",
@@ -1431,6 +1438,19 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-DzBIhmBPgPAf/Hf4oHVgNNrcYcmAwV6v1TeZFkEaotO5AtXEfCJ6c07Po4EmylAA0PFp+8+S77PBEcLNEMOCGQ==",
+      "dependencies": {
+        "axios": "1.1.3"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "9.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.1.5.tgz",
@@ -1996,6 +2016,14 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -2130,10 +2158,29 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/passport-jwt": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-3.0.7.tgz",
+      "integrity": "sha512-qRQ4qlww1Yhs3IaioDKrsDNmKy6gLDLgFsGwpCnc2YqWovO2Oxu9yCQdWHMJafQ7UIuOba4C4/TNXcGkQfEjlQ==",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
     "node_modules/@types/passport-kakao": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.0.tgz",
       "integrity": "sha512-wxBJdc4ThRTPrCN3JvnwnV+6PJJjso2WjcWuAgIghZtLmK8F/qfgAIKtWKeDoRYTPbZ0MSsjuCQhlXmDqrNicA==",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
+      "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*"
@@ -2194,6 +2241,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.13",
@@ -2762,8 +2814,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "28.1.3",
@@ -3395,7 +3456,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3471,6 +3531,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3604,7 +3684,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4423,6 +4502,25 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -4477,7 +4575,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6865,6 +6962,15 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "dependencies": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
     "node_modules/passport-kakao": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
@@ -7146,6 +7252,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -10094,6 +10205,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@nestjs/axios": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-1.0.0.tgz",
+      "integrity": "sha512-DzBIhmBPgPAf/Hf4oHVgNNrcYcmAwV6v1TeZFkEaotO5AtXEfCJ6c07Po4EmylAA0PFp+8+S77PBEcLNEMOCGQ==",
+      "requires": {
+        "axios": "1.1.3"
+      }
+    },
     "@nestjs/cli": {
       "version": "9.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.1.5.tgz",
@@ -10504,6 +10623,14 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
@@ -10638,10 +10765,29 @@
         "@types/express": "*"
       }
     },
+    "@types/passport-jwt": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-3.0.7.tgz",
+      "integrity": "sha512-qRQ4qlww1Yhs3IaioDKrsDNmKy6gLDLgFsGwpCnc2YqWovO2Oxu9yCQdWHMJafQ7UIuOba4C4/TNXcGkQfEjlQ==",
+      "requires": {
+        "@types/express": "*",
+        "@types/jsonwebtoken": "*",
+        "@types/passport-strategy": "*"
+      }
+    },
     "@types/passport-kakao": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.0.tgz",
       "integrity": "sha512-wxBJdc4ThRTPrCN3JvnwnV+6PJJjso2WjcWuAgIghZtLmK8F/qfgAIKtWKeDoRYTPbZ0MSsjuCQhlXmDqrNicA==",
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "@types/passport-strategy": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.35.tgz",
+      "integrity": "sha512-o5D19Jy2XPFoX2rKApykY15et3Apgax00RRLf0RUotPDUsYrQa7x4howLYr9El2mlUApHmCMv5CZ1IXqKFQ2+g==",
       "requires": {
         "@types/express": "*",
         "@types/passport": "*"
@@ -10702,6 +10848,11 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/yargs": {
       "version": "17.0.13",
@@ -11122,8 +11273,17 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-jest": {
       "version": "28.1.3",
@@ -11579,7 +11739,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -11640,6 +11799,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -11739,8 +11914,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -12373,6 +12547,11 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -12409,7 +12588,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -14201,6 +14379,15 @@
         "utils-merge": "^1.0.1"
       }
     },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
     "passport-kakao": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/passport-kakao/-/passport-kakao-1.0.1.tgz",
@@ -14405,6 +14592,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pump": {
       "version": "3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
@@ -28,14 +29,20 @@
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/typeorm": "^9.0.1",
+    "@types/cookie-parser": "^1.4.3",
+    "@types/passport-jwt": "^3.0.7",
     "@types/passport-kakao": "^1.0.0",
+    "@types/uuid": "^8.3.4",
+    "cookie-parser": "^1.4.6",
     "mysql": "^2.18.1",
     "passport": "^0.6.0",
+    "passport-jwt": "^4.0.0",
     "passport-kakao": "^1.0.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
-    "typeorm": "^0.3.10"
+    "typeorm": "^0.3.10",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -6,6 +6,7 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import configuration from './config/configuration';
 import TypeOrmConfigService from './config/typeorm.config';
+import { SessionMiddleware } from './middleware/session.middleware';
 
 @Module({
   imports: [
@@ -20,6 +21,13 @@ import TypeOrmConfigService from './config/typeorm.config';
     AuthModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, SessionMiddleware],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  constructor(public sessionMiddleware: SessionMiddleware) {}
+
+  configure(consumer: MiddlewareConsumer) {
+    // jwt 토큰이 쿠키에 저장되므로 모든 경로에 대해 미들웨어 적용.
+    consumer.apply(this.sessionMiddleware.cookieParser).forRoutes('*');
+  }
+}

--- a/backend/src/auth/auth.kakao.controller.ts
+++ b/backend/src/auth/auth.kakao.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import { Controller, Get, Logger, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { User } from 'src/decorator/user.decorator';
 import { UserSessionDto } from 'src/dto/user.session.dto';
@@ -10,6 +10,7 @@ import { KakaoGuard } from './kakao/guard/kakao.guard';
 
 @Controller('auth/kakao')
 export class AuthKakaoController {
+  private logger = new Logger(AuthKakaoController.name);
   constructor(
     private authService: AuthService,
     ){}
@@ -17,14 +18,13 @@ export class AuthKakaoController {
   @Get('/login')
   @UseGuards(KakaoGuard)
   async login() {
-    console.log('login success!');
+    this.logger.log('Try login...');
   }
 
   @Get('/login/callback')
   @UseGuards(KakaoGuard, JWTSignGuard)
-  async loginCallback(@Res() res: Response, @User() user: UserSessionDto) {
-    console.log('callback success!');
-    console.log(user);
+  async loginCallback(@Res() res: Response) {
+    this.logger.log('login success!');
     return res.redirect('/');
   }
 

--- a/backend/src/auth/auth.kakao.controller.ts
+++ b/backend/src/auth/auth.kakao.controller.ts
@@ -2,12 +2,17 @@ import { Controller, Get, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { User } from 'src/decorator/user.decorator';
 import { UserSessionDto } from 'src/dto/user.session.dto';
+import { UserSocialDto } from 'src/dto/user.social.dto';
 import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './jwt/guard/jwt.auth.guard';
+import { JWTSignGuard } from './jwt/guard/jwt.sign.guard';
 import { KakaoGuard } from './kakao/guard/kakao.guard';
 
-@Controller('auth')
-export class AuthController {
-  constructor(private authService: AuthService){}
+@Controller('auth/kakao')
+export class AuthKakaoController {
+  constructor(
+    private authService: AuthService,
+    ){}
 
   @Get('/login')
   @UseGuards(KakaoGuard)
@@ -16,17 +21,17 @@ export class AuthController {
   }
 
   @Get('/login/callback')
-  @UseGuards(KakaoGuard)
+  @UseGuards(KakaoGuard, JWTSignGuard)
   async loginCallback(@Res() res: Response, @User() user: UserSessionDto) {
     console.log('callback success!');
     console.log(user);
-    // await this.authService.addUserIfNotExists(user);
     return res.redirect('/');
   }
 
-  // @Get('/logout')
-  // async logout(@Res() res: Response) {
-  //   console.log('logout success!');
-  //   return res.redirect('/');
-  // }
+  @Get('/logout')
+  @UseGuards(JwtAuthGuard)
+  async logout(@Res() res: Response, @User() user: UserSessionDto) {
+    await this.authService.logout(res, user);
+    return res.redirect('/');
+  }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,9 +1,21 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
-import { AuthController } from './auth.controller';
+import { HttpModule } from '@nestjs/axios';
+import { AuthKakaoController } from './auth.kakao.controller';
 import { KakaoStrategy } from './kakao/kakao.strategy';
 import { AuthService } from './auth.service';
+import { AuthRepository } from './repository/auth.repository';
+import User from 'src/entities/user.entity';
+import AuthSocial from 'src/entities/auth.social.entity';
+import AuthSite from 'src/entities/auth.site.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtStrategy } from './jwt/jwt.strategy';
+
+const repo = {
+  provide: 'IAuthRepository',
+  useClass: AuthRepository,
+};
 
 @Module({
   imports: [
@@ -16,9 +28,11 @@ import { AuthService } from './auth.service';
       }),
       inject: [ConfigService],
     }),
+    TypeOrmModule.forFeature([User, AuthSocial, AuthSite]),
+    HttpModule,
   ],
-  providers: [KakaoStrategy, AuthService],
-  controllers: [AuthController],
+  providers: [KakaoStrategy, JwtStrategy, AuthService, repo],
+  controllers: [AuthKakaoController],
   exports: [],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { UserSocialDto } from 'src/dto/user.social.dto';
 import { IAuthRepository } from './repository/auth.repository.interface';
 import { v4 as uuid } from 'uuid';
@@ -7,18 +7,18 @@ import { UserDto } from 'src/dto/user.dto';
 import SocialType from 'src/enums/social.type.enum';
 import { HttpService } from '@nestjs/axios';
 import { firstValueFrom, map } from 'rxjs';
-import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
 
 @Injectable()
 export class AuthService {
+  private logger = new Logger(AuthService.name);
   constructor(
     @Inject('IAuthRepository') private authRepository: IAuthRepository,
-    // private configService: ConfigService,
     private readonly httpService: HttpService,
   ) {}
 
   async addSocialUserIfNotExists(user: UserSessionDto): Promise<UserDto> {
+    this.logger.debug(`Called ${this.addSocialUserIfNotExists.name}`);
     // user 테이블에서 userId로 auth_social에서 유저 조회.
     // 이미 존재하는 유저라면 null return
     if (await this.authRepository.findSocialUserByUserId(user.socialUserId, user.socialType)) {
@@ -33,15 +33,13 @@ export class AuthService {
     return { userId, userName };
   }
 
-  async getUserNameById(userId: number): Promise<string> {
-    return await this.authRepository.getUserNameById(userId);
-  }
-
   async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
+    this.logger.debug(`Called ${this.getUserDtoBySocialUserId.name}`);
     return await this.authRepository.getUserDtoBySocialUserId(socialUserId, socialType);
   }
 
   async logout(res: Response, user: UserSessionDto): Promise<void> {
+    this.logger.debug(`Called ${this.logout.name}`);
     const url = 'https://kapi.kakao.com/v1/user/logout';
     const headersRequest = {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,6 +1,64 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { UserSocialDto } from 'src/dto/user.social.dto';
+import { IAuthRepository } from './repository/auth.repository.interface';
+import { v4 as uuid } from 'uuid';
+import { UserSessionDto } from 'src/dto/user.session.dto';
+import { UserDto } from 'src/dto/user.dto';
+import SocialType from 'src/enums/social.type.enum';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom, map } from 'rxjs';
+import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
 
 @Injectable()
 export class AuthService {
+  constructor(
+    @Inject('IAuthRepository') private authRepository: IAuthRepository,
+    // private configService: ConfigService,
+    private readonly httpService: HttpService,
+  ) {}
 
+  async addSocialUserIfNotExists(user: UserSessionDto): Promise<UserDto> {
+    // user 테이블에서 userId로 auth_social에서 유저 조회.
+    // 이미 존재하는 유저라면 null return
+    if (await this.authRepository.findSocialUserByUserId(user.socialUserId, user.socialType)) {
+      return null;
+    }
+    // 없었던 유저라면 랜덤 userName을 생성.
+    const userName = uuid();
+    // user 테이블에 삽입.
+    const userId = await this.authRepository.addSocialUser(userName, user.email)
+    // auth_social에 삽입.
+    await this.authRepository.insertAuthSocial(userId, user);
+    return { userId, userName };
+  }
+
+  async getUserNameById(userId: number): Promise<string> {
+    return await this.authRepository.getUserNameById(userId);
+  }
+
+  async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
+    return await this.authRepository.getUserDtoBySocialUserId(socialUserId, socialType);
+  }
+
+  async logout(res: Response, user: UserSessionDto): Promise<void> {
+    const url = 'https://kapi.kakao.com/v1/user/logout';
+    const headersRequest = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${user.accessToken}`,
+    };
+    await firstValueFrom(
+      this.httpService
+        .get(url, { headers: headersRequest })
+        .pipe(map((res) => res.data)),
+      )
+      .then((data) => {
+        console.log(data);
+        res.clearCookie('populmap_token');
+        console.log('logout success!');
+      })
+      .catch((err) => {
+        throw err;
+      });
+  }
 }

--- a/backend/src/auth/jwt/guard/jwt.auth.guard.ts
+++ b/backend/src/auth/jwt/guard/jwt.auth.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable, UnauthorizedException } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+/**
+ * passport-jwt의 기본 인증을 사용.
+ * 401 에러 시 커스텀 에러 메시지만 추가
+ */
+ @Injectable()
+ export class JwtAuthGuard extends AuthGuard('jwt') {
+   handleRequest<TUser = any>(err: any, user: any): TUser {
+     if (err || !user) {
+      console.log(err);
+      console.log(user);
+      throw (
+         err ||
+         new UnauthorizedException(
+           '🚨 로그인 정보가 만료되었습니다. 🥲 🚨\n다시 로그인해주세요.',
+         )
+       );
+     }
+     return user;
+   }
+ }

--- a/backend/src/auth/jwt/guard/jwt.sign.guard.ts
+++ b/backend/src/auth/jwt/guard/jwt.sign.guard.ts
@@ -1,0 +1,47 @@
+import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { Request, Response } from "express";
+import { Observable } from "rxjs";
+import { AuthService } from "src/auth/auth.service";
+import { UserSessionDto } from "src/dto/user.session.dto";
+import { UserSocialDto } from "src/dto/user.social.dto";
+import LoginType from "src/enums/login.type.enum";
+
+@Injectable()
+export class JWTSignGuard implements CanActivate {
+  private logger = new Logger(JWTSignGuard.name);
+
+  constructor(
+    private jwtService: JwtService,
+    private authService: AuthService,
+    ) {}
+
+  async canActivate(
+    context: ExecutionContext,
+  ): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+    return await this.generateJWTToken(req, res);
+  }
+
+  private async generateJWTToken(request: Request, response: Response): Promise<boolean> {
+    const user = request.user as UserSessionDto | undefined;
+    if (user === undefined) {
+      this.logger.debug(`can't generate JWTToken`);
+      return false;
+    }
+    console.log('jwt sign guard generateJWTToken');
+    if (user.loginType === LoginType.SOCIAL) {
+      const generatedUser = await this.authService.addSocialUserIfNotExists(user);
+      if (generatedUser) {
+        user.userId = generatedUser.userId;
+        user.userName = generatedUser.userName;
+      }
+    } else {
+      // await this.authService.addSiteUserIfNotExists(user);
+    }
+    const token = this.jwtService.sign(user);
+    response.cookie('populmap_token', token);
+    return true;
+  }
+}

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy } from 'passport-jwt';
+import { AuthService } from "../auth.service";
+
+const extracter = (req) => {
+  let token = null;
+  if (req && req.cookies) {
+    token = req.cookies['populmap_token'];
+  }
+  return token;
+};
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(
+    @Inject(ConfigService) private configService: ConfigService,
+    private authService: AuthService,
+  ) {
+    super({
+      jwtFromRequest: extracter,
+      secretOrKey: configService.get<string>('jwt.secret'),
+    });
+  }
+
+  async validate(payload: any) {
+    console.log('jwt strate validate');
+    console.log(payload);
+    return payload;
+  }
+}

--- a/backend/src/auth/jwt/jwt.strategy.ts
+++ b/backend/src/auth/jwt/jwt.strategy.ts
@@ -25,8 +25,6 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: any) {
-    console.log('jwt strate validate');
-    console.log(payload);
     return payload;
   }
 }

--- a/backend/src/auth/kakao/kakao.strategy.ts
+++ b/backend/src/auth/kakao/kakao.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
 import { Strategy } from "passport-kakao";
@@ -22,10 +22,8 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   }
 
   async validate(accessToken, refreshToken, profile, callback) {
-    console.log('kakao strate validate');
     const profile_json = profile._json;
     const kakao_account = profile_json.kakao_account;
-    // let user;
     const user: UserSessionDto = {
       userId: undefined,
       userName: undefined,

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -1,10 +1,43 @@
 import { UserDto } from "src/dto/user.dto";
+import { UserSessionDto } from "src/dto/user.session.dto";
+import { UserSocialDto } from "src/dto/user.social.dto";
+import SocialType from "src/enums/social.type.enum";
 
 export interface IAuthRepository {
 
+
   /**
-   *
+   * socialUserId으로 해당 소셜 플랫폼의 유저가 존재하는지 확인한다.
+   * @param socialUserId
+   * @param socialType
+   */
+  findSocialUserByUserId(socialUserId: number, socialType: SocialType): Promise<Boolean>;
+
+  /**
+   * 새로운 소셜 로그인 유저를 추가한다.
+   * @param userName
+   * @param email
+   * @return user_id
+   */
+  addSocialUser(userName: string, email: string): Promise<number>;
+
+  /**
+   * auth.social 테이블에 새 유저 정보를 추가한다.
+   * @param userId
    * @param user
    */
-  addUserIfNotExists(user: UserDto): Promise<boolean>;
+  insertAuthSocial(userId: number, user: UserSessionDto): Promise<void>;
+
+  /**
+   * userId로 userName을 얻는다.
+   * @param userId
+   */
+  getUserNameById(userId: number): Promise<string>;
+
+  /**
+   * socialUserId와 socialType으로 userDto를 얻는다.
+   * 존재하지 않으면 null을 반환한다.
+   * @param socialUserId
+   */
+  getUserDtoBySocialUserId(socialUserId: number, socailType: SocialType): Promise<UserDto>;
 }

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -29,12 +29,6 @@ export interface IAuthRepository {
   insertAuthSocial(userId: number, user: UserSessionDto): Promise<void>;
 
   /**
-   * userId로 userName을 얻는다.
-   * @param userId
-   */
-  getUserNameById(userId: number): Promise<string>;
-
-  /**
    * socialUserId와 socialType으로 userDto를 얻는다.
    * 존재하지 않으면 null을 반환한다.
    * @param socialUserId

--- a/backend/src/auth/repository/auth.repository.ts
+++ b/backend/src/auth/repository/auth.repository.ts
@@ -52,18 +52,6 @@ export class AuthRepository implements IAuthRepository {
     });
   }
 
-  async getUserNameById(userId: number): Promise<string> {
-    const result = await this.userRepository.findOne({
-      select: {
-        userName: true,
-      },
-      where: {
-        userId: userId,
-      }
-    });
-    return result.userName;
-  }
-
   async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
     const result = await this.authSocialRepository.findOne({
       relations: ['user'],

--- a/backend/src/auth/repository/auth.repository.ts
+++ b/backend/src/auth/repository/auth.repository.ts
@@ -1,11 +1,98 @@
 import { IAuthRepository } from "./auth.repository.interface";
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from "typeorm";
+import User from "src/entities/user.entity";
+import AuthSocial from "src/entities/auth.social.entity";
+import { UserSocialDto } from "src/dto/user.social.dto";
+import LoginType from "src/enums/login.type.enum";
+import { UserSessionDto } from "src/dto/user.session.dto";
+import SocialType from "src/enums/social.type.enum";
+import { UserDto } from "src/dto/user.dto";
 
 
-// export class AuthRepository implements IAuthRepository {
-//   constructor(
-//     @InjectRepository(User) private userRepository: Repository<User>,
-//   ) {}
+export class AuthRepository implements IAuthRepository {
+  constructor(
+    @InjectRepository(AuthSocial)
+    private authSocialRepository: Repository<AuthSocial>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
 
-// }
+
+  async findSocialUserByUserId(socialUserId: number, socialType: SocialType): Promise<Boolean> {
+    const result = await this.authSocialRepository.findOne({
+      where: {
+        socialUserId: socialUserId,
+        socialType: socialType,
+      },
+    });
+    if (!result) {
+      return false;
+    }
+    return true;
+  }
+
+  async addSocialUser(userName: string, email: string): Promise<number> {
+    const result = await this.userRepository.insert({
+      userName: userName,
+      email: email,
+      loginType: LoginType.SOCIAL,
+    });
+    return result.identifiers.pop()['userId'];
+  }
+
+  async insertAuthSocial(userId: number, user: UserSessionDto): Promise<void> {
+    await this.authSocialRepository.insert({
+      userId: userId,
+      socialUserId: user.socialUserId,
+      socialType: user.socialType,
+      accessToken: user.accessToken,
+      firstLogin: new Date(),
+      lastLogin: new Date(),
+    });
+  }
+
+  async getUserNameById(userId: number): Promise<string> {
+    const result = await this.userRepository.findOne({
+      select: {
+        userName: true,
+      },
+      where: {
+        userId: userId,
+      }
+    });
+    return result.userName;
+  }
+
+  async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
+    const result = await this.authSocialRepository.findOne({
+      relations: ['user'],
+      select: {
+        user: {
+          userId: true,
+          userName: true,
+        }
+      },
+      where: {
+        socialUserId: socialUserId,
+        socialType: socialType,
+      },
+    });
+    // const result = await this.authSocialRepository.createQueryBuilder()
+    // .select('user.userId', 'userId')
+    // .addSelect('user.userName', 'userName')
+    // .from(User, 'user')
+    // .innerJoin(AuthSocial, 'authSocial', 'user.userId = authSocial.userId')
+    // .where('authSocial.socialUserId = :socialUserId', { socialUserId: socialUserId })
+    // .andWhere('authSocial.socialType = :socialType', { socialType: socialType })
+    // .getOne();
+    console.log(result);
+    if (!result) {
+      return null;
+    }
+    return {
+      userId: result.user.userId,
+      userName: result.user.userName,
+    }
+  }
+}

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -16,4 +16,7 @@ export default () => ({
     user: process.env.DATABASE_USER,
     password: process.env.DATABASE_PASSWORD,
   },
+  debug: {
+    log: process.env.DEBUG_LOG === 'true' ? true : false,
+  },
 });

--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -8,7 +8,6 @@ export default class TypeOrmConfigService implements TypeOrmOptionsFactory {
 
   createTypeOrmOptions(): TypeOrmModuleOptions | Promise<TypeOrmModuleOptions> {
     const log = this.configService.get<boolean>('debug.log');
-
     return {
       type: 'mysql',
       host: this.configService.get<string>('database.host'),

--- a/backend/src/dto/user.dto.ts
+++ b/backend/src/dto/user.dto.ts
@@ -1,6 +1,5 @@
 export class UserDto {
-  user_id: number; // 카카오에서 제공해준 user_id
-  nickname: string; // 유저의 닉네임
-  profile_url?: string; // 카카오 프사 url
-  email?: string; // 카카오 등록 email
+  userId: number;
+  userName: string;
+  email?: string;
 }

--- a/backend/src/dto/user.session.dto.ts
+++ b/backend/src/dto/user.session.dto.ts
@@ -1,5 +1,12 @@
+import LoginType from "src/enums/login.type.enum";
+import SocialType from "src/enums/social.type.enum";
 import { UserDto } from "./user.dto";
 
 export class UserSessionDto extends UserDto {
-  access_token: string;
+  loginType: LoginType;
+  socialType?: SocialType;
+  socialUserId?: number;
+  accessToken: string;
+  iat?: number;
+  exp?: number;
 }

--- a/backend/src/dto/user.social.dto.ts
+++ b/backend/src/dto/user.social.dto.ts
@@ -1,0 +1,8 @@
+import SocialType from "src/enums/social.type.enum";
+import { UserDto } from "./user.dto";
+
+export class UserSocialDto {
+  email?: string;
+  socialType: SocialType;
+  accessToken: string;
+}

--- a/backend/src/entities/auth.site.entity.ts
+++ b/backend/src/entities/auth.site.entity.ts
@@ -1,12 +1,12 @@
 import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import User from "./user.entity";
 
-@Entity('auth.site')
+@Entity('auth_site')
 export default class AuthSite {
   @PrimaryGeneratedColumn({
-    name: 'siteId',
+    name: 'site_id',
   })
-  site_id: number;
+  siteId: number;
 
   @Column({
     name: 'site_user_id',
@@ -34,7 +34,7 @@ export default class AuthSite {
 
   @OneToOne(() => User)
   @JoinColumn({
-    name: 'user_id',
+    name: 'site_user_id',
   })
   user: User;
 }

--- a/backend/src/entities/auth.social.entity.ts
+++ b/backend/src/entities/auth.social.entity.ts
@@ -2,7 +2,7 @@ import SocialType from "src/enums/social.type.enum";
 import { Column, CreateDateColumn, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import User from "./user.entity";
 
-@Entity('auth.social')
+@Entity('auth_social')
 export default class AuthSocial {
   @PrimaryGeneratedColumn({
     name: 'social_id',
@@ -11,10 +11,16 @@ export default class AuthSocial {
 
   @Column({
     name: 'social_user_id',
-    unique: true,
     type: 'int',
+    nullable: true,
   })
   socialUserId: number;
+
+  @Column({
+    name: 'user_id',
+    unique: true,
+  })
+  userId: number;
 
   @Column({
     name: 'social_type',

--- a/backend/src/enums/login.type.enum.ts
+++ b/backend/src/enums/login.type.enum.ts
@@ -1,4 +1,3 @@
-
 enum LoginType {
   SOCIAL = 'SOCIAL',
   SITE = 'SITE',

--- a/backend/src/middleware/middleware.d.ts
+++ b/backend/src/middleware/middleware.d.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+
+export type Middleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => void;

--- a/backend/src/middleware/session.middleware.ts
+++ b/backend/src/middleware/session.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Middleware } from "./middleware";
+import * as cookieParser from 'cookie-parser';
+
+@Injectable()
+export class SessionMiddleware {
+  cookieParser: Middleware;
+
+  constructor(private configService: ConfigService) {
+    this.cookieParser = cookieParser();
+  }
+}


### PR DESCRIPTION

# 추가 기능
1.  카카오 인증을 위한 `Strategy`을 작성했습니다.
2. `passport-kakao`에서 제공하는 기능을 이용하여 `KakaoGuard` 추가했습니다.
3.  서비스 자체에서 인증 수단으로 사용하기 위해 `JWT` 토큰 인증을 구현했습니다.
-> `KakaoGuard`를 통과하면 `JWTSignGuard`에서 새 토큰을 발행.
4.  `accessToken`과 `refreshToken`을 만료시킬 수 있는 `로그아웃` 기능을 구현했습니다.


# TODO
- 네이버와 구글 로그인 인증 구현 필요.
- 사이트 자체 회원가입 인증 구현 필요.