### PR TITLE
네이버 로그인 API 인증 구현

### DIFF
--- a/backend/database/populmap.sql
+++ b/backend/database/populmap.sql
@@ -53,7 +53,7 @@ DROP TABLE IF EXISTS `auth_social`;
 CREATE TABLE `auth_social` (
   `social_id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL COMMENT 'user의 fk',
-  `social_user_id` bigint DEFAULT NULL,
+  `social_user_id` varchar(64) DEFAULT NULL,
   `social_type` varchar(16) NOT NULL,
   `access_token` varchar(256) NOT NULL,
   `first_login` datetime DEFAULT NULL,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.0",
         "passport-kakao": "^1.0.1",
+        "passport-naver": "^1.0.6",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
@@ -6980,6 +6981,44 @@
         "pkginfo": "~0.3.0"
       }
     },
+    "node_modules/passport-naver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz",
+      "integrity": "sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==",
+      "dependencies": {
+        "passport-oauth": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "node_modules/passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==",
+      "dependencies": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.2.0.tgz",
+      "integrity": "sha512-Sv2YWodC6jN12M/OXwmR4BIXeeIHjjbwYTQw4kS6tHK4zYzSEpxBgSJJnknBjICA5cj0ju3FSnG1XmHgIhYnLg==",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
     "node_modules/passport-oauth2": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
@@ -8702,6 +8741,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "node_modules/underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/universalify": {
       "version": "2.0.0",
@@ -14397,6 +14441,34 @@
         "pkginfo": "~0.3.0"
       }
     },
+    "passport-naver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz",
+      "integrity": "sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==",
+      "requires": {
+        "passport-oauth": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==",
+      "requires": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth1": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.2.0.tgz",
+      "integrity": "sha512-Sv2YWodC6jN12M/OXwmR4BIXeeIHjjbwYTQw4kS6tHK4zYzSEpxBgSJJnknBjICA5cj0ju3FSnG1XmHgIhYnLg==",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      }
+    },
     "passport-oauth2": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz",
@@ -15574,6 +15646,11 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
       "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA=="
+    },
+    "underscore": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
     "passport-kakao": "^1.0.1",
+    "passport-naver": "^1.0.6",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",

--- a/backend/src/auth/auth.kakao.controller.ts
+++ b/backend/src/auth/auth.kakao.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get, Logger, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { User } from 'src/decorator/user.decorator';
 import { UserSessionDto } from 'src/dto/user.session.dto';
-import { UserSocialDto } from 'src/dto/user.social.dto';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt/guard/jwt.auth.guard';
 import { JWTSignGuard } from './jwt/guard/jwt.sign.guard';

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -11,6 +11,8 @@ import AuthSocial from 'src/entities/auth.social.entity';
 import AuthSite from 'src/entities/auth.site.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtStrategy } from './jwt/jwt.strategy';
+import { AuthNaverController } from './auth.naver.controller';
+import { NaverStrategy } from './naver/naver.strategy';
 
 const repo = {
   provide: 'IAuthRepository',
@@ -31,8 +33,8 @@ const repo = {
     TypeOrmModule.forFeature([User, AuthSocial, AuthSite]),
     HttpModule,
   ],
-  providers: [KakaoStrategy, JwtStrategy, AuthService, repo],
-  controllers: [AuthKakaoController],
+  providers: [KakaoStrategy, NaverStrategy, JwtStrategy, AuthService, repo],
+  controllers: [AuthKakaoController, AuthNaverController],
   exports: [],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.naver.controller.ts
+++ b/backend/src/auth/auth.naver.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Logger, Res, UseGuards } from "@nestjs/common";
+import { Response } from "express";
+import { User } from "src/decorator/user.decorator";
+import { UserSessionDto } from "src/dto/user.session.dto";
+import { AuthService } from "./auth.service";
+import { JwtAuthGuard } from "./jwt/guard/jwt.auth.guard";
+import { JWTSignGuard } from "./jwt/guard/jwt.sign.guard";
+import { NaverGuard } from "./naver/guard/naver.guard";
+
+
+@Controller('auth/naver')
+export class AuthNaverController {
+  private logger = new Logger(AuthNaverController.name);
+  constructor(
+    private authService: AuthService,
+    ){}
+
+  @Get('/login')
+  @UseGuards(NaverGuard)
+  async login() {
+    this.logger.log('Try login...');
+  }
+
+  @Get('/login/callback')
+  @UseGuards(NaverGuard, JWTSignGuard)
+  async loginCallback(@Res() res: Response) {
+    this.logger.log('login success!');
+    return res.redirect('/');
+  }
+
+  @Get('/logout')
+  @UseGuards(JwtAuthGuard)
+  async logout(@Res() res: Response, @User() user: UserSessionDto) {
+    await this.authService.logout(res, user);
+    return res.redirect('/');
+  }
+}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { UserSocialDto } from 'src/dto/user.social.dto';
 import { IAuthRepository } from './repository/auth.repository.interface';
 import { v4 as uuid } from 'uuid';
 import { UserSessionDto } from 'src/dto/user.session.dto';
@@ -21,6 +20,9 @@ export class AuthService {
     this.logger.debug(`Called ${this.addSocialUserIfNotExists.name}`);
     // user 테이블에서 userId로 auth_social에서 유저 조회.
     // 이미 존재하는 유저라면 null return
+    if (await this.authRepository.findUserByEmail(user.email)) {
+      return null;
+    }
     if (await this.authRepository.findSocialUserByUserId(user.socialUserId, user.socialType)) {
       return null;
     }
@@ -33,7 +35,7 @@ export class AuthService {
     return { userId, userName };
   }
 
-  async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
+  async getUserDtoBySocialUserId(socialUserId: string, socialType: SocialType): Promise<UserDto> {
     this.logger.debug(`Called ${this.getUserDtoBySocialUserId.name}`);
     return await this.authRepository.getUserDtoBySocialUserId(socialUserId, socialType);
   }

--- a/backend/src/auth/jwt/guard/jwt.sign.guard.ts
+++ b/backend/src/auth/jwt/guard/jwt.sign.guard.ts
@@ -4,7 +4,6 @@ import { Request, Response } from "express";
 import { Observable } from "rxjs";
 import { AuthService } from "src/auth/auth.service";
 import { UserSessionDto } from "src/dto/user.session.dto";
-import { UserSocialDto } from "src/dto/user.social.dto";
 import LoginType from "src/enums/login.type.enum";
 
 @Injectable()

--- a/backend/src/auth/naver/guard/naver.guard.ts
+++ b/backend/src/auth/naver/guard/naver.guard.ts
@@ -1,0 +1,8 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+/**
+ * passport-kakao의 기본 인증을 사용한다.
+ */
+@Injectable()
+export class NaverGuard extends AuthGuard('naver') {}

--- a/backend/src/auth/naver/naver.strategy.ts
+++ b/backend/src/auth/naver/naver.strategy.ts
@@ -1,22 +1,22 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { PassportStrategy } from "@nestjs/passport";
-import { Strategy } from "passport-kakao";
+import { Strategy } from "passport-naver";
 import { UserSessionDto } from "src/dto/user.session.dto";
 import LoginType from "src/enums/login.type.enum";
 import SocialType from "src/enums/social.type.enum";
 import { AuthService } from "../auth.service";
 
 @Injectable()
-export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
   constructor(
     private readonly configService: ConfigService,
     private readonly authService: AuthService,
     ) {
     super({
-      clientID: configService.get<string>('kakao.clientID'),
-      clientSecret: configService.get<string>('kakao.clientSecret'),
-      callbackURL: configService.get<string>('kakao.callbackURL'),
+      clientID: configService.get<string>('naver.clientID'),
+      clientSecret: configService.get<string>('naver.clientSecret'),
+      callbackURL: configService.get<string>('naver.callbackURL'),
     });
   }
 
@@ -26,10 +26,10 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     const user: UserSessionDto = {
       userId: undefined,
       userName: undefined,
-      email: kakao_account.has_email ? kakao_account.email : null,
+      email: profile.emails[0].value,
       loginType: LoginType.SOCIAL,
-      socialType: SocialType.KAKAO,
-      socialUserId: String(profile.id),
+      socialType: SocialType.NAVER,
+      socialUserId: profile.id,
       accessToken: accessToken,
     };
     const existingUser = await this.authService.getUserDtoBySocialUserId(user.socialUserId, user.socialType);
@@ -40,4 +40,3 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     callback(null, user);
   }
 }
-

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -1,17 +1,21 @@
 import { UserDto } from "src/dto/user.dto";
 import { UserSessionDto } from "src/dto/user.session.dto";
-import { UserSocialDto } from "src/dto/user.social.dto";
 import SocialType from "src/enums/social.type.enum";
 
 export interface IAuthRepository {
 
+  /**
+   * email로 해당 유저가 이미 존재하는지 확인한다.
+   * @param email
+   */
+  findUserByEmail(email: string): Promise<Boolean>;
 
   /**
    * socialUserId으로 해당 소셜 플랫폼의 유저가 존재하는지 확인한다.
    * @param socialUserId
    * @param socialType
    */
-  findSocialUserByUserId(socialUserId: number, socialType: SocialType): Promise<Boolean>;
+  findSocialUserByUserId(socialUserId: string, socialType: SocialType): Promise<Boolean>;
 
   /**
    * 새로운 소셜 로그인 유저를 추가한다.
@@ -33,5 +37,5 @@ export interface IAuthRepository {
    * 존재하지 않으면 null을 반환한다.
    * @param socialUserId
    */
-  getUserDtoBySocialUserId(socialUserId: number, socailType: SocialType): Promise<UserDto>;
+  getUserDtoBySocialUserId(socialUserId: string, socailType: SocialType): Promise<UserDto>;
 }

--- a/backend/src/auth/repository/auth.repository.ts
+++ b/backend/src/auth/repository/auth.repository.ts
@@ -3,7 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from "typeorm";
 import User from "src/entities/user.entity";
 import AuthSocial from "src/entities/auth.social.entity";
-import { UserSocialDto } from "src/dto/user.social.dto";
 import LoginType from "src/enums/login.type.enum";
 import { UserSessionDto } from "src/dto/user.session.dto";
 import SocialType from "src/enums/social.type.enum";
@@ -18,8 +17,19 @@ export class AuthRepository implements IAuthRepository {
     private userRepository: Repository<User>,
   ) {}
 
+  async findUserByEmail(email: string): Promise<Boolean> {
+    const result = await this.userRepository.findOne({
+      where: {
+        email: email,
+      }
+    });
+    if (!result) {
+      return false;
+    }
+    return true;
+  }
 
-  async findSocialUserByUserId(socialUserId: number, socialType: SocialType): Promise<Boolean> {
+  async findSocialUserByUserId(socialUserId: string, socialType: SocialType): Promise<Boolean> {
     const result = await this.authSocialRepository.findOne({
       where: {
         socialUserId: socialUserId,
@@ -52,7 +62,7 @@ export class AuthRepository implements IAuthRepository {
     });
   }
 
-  async getUserDtoBySocialUserId(socialUserId: number, socialType: SocialType): Promise<UserDto> {
+  async getUserDtoBySocialUserId(socialUserId: string, socialType: SocialType): Promise<UserDto> {
     const result = await this.authSocialRepository.findOne({
       relations: ['user'],
       select: {

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -9,6 +9,11 @@ export default () => ({
     clientSecret: process.env.KAKAO_CLIENT_SECRET,
     callbackURL: process.env.KAKAO_CALLBACK_URL,
   },
+  naver: {
+    clientID: process.env.NAVER_CLIENT_ID,
+    clientSecret: process.env.NAVER_CLIENT_SECRET,
+    callbackURL: process.env.NAVER_CALLBACK_URL,
+  },
   database: {
     database: process.env.DATABASE,
     host: process.env.DATABASE_HOST,

--- a/backend/src/dto/user.session.dto.ts
+++ b/backend/src/dto/user.session.dto.ts
@@ -5,7 +5,7 @@ import { UserDto } from "./user.dto";
 export class UserSessionDto extends UserDto {
   loginType: LoginType;
   socialType?: SocialType;
-  socialUserId?: number;
+  socialUserId?: string;
   accessToken: string;
   iat?: number;
   exp?: number;

--- a/backend/src/dto/user.social.dto.ts
+++ b/backend/src/dto/user.social.dto.ts
@@ -1,8 +1,0 @@
-import SocialType from "src/enums/social.type.enum";
-import { UserDto } from "./user.dto";
-
-export class UserSocialDto {
-  email?: string;
-  socialType: SocialType;
-  accessToken: string;
-}

--- a/backend/src/entities/auth.social.entity.ts
+++ b/backend/src/entities/auth.social.entity.ts
@@ -11,10 +11,11 @@ export default class AuthSocial {
 
   @Column({
     name: 'social_user_id',
-    type: 'int',
+    type: 'varchar',
+    length: 64,
     nullable: true,
   })
-  socialUserId: number;
+  socialUserId: string;
 
   @Column({
     name: 'user_id',


### PR DESCRIPTION
카카오 로그인 API 인증과 마찬가지 방식으로 구현했습니다.

# 추가 기능

네이버 인증을 위한 `Strategy`을 작성했습니다.
`passport-naver`에서 제공하는 기능을 이용하여 `NaverGuard` 추가했습니다.

# 변경 사항

1. 네이버에서 제공해주는 id는 카카오와 달리 `string`이므로 `socialUserId`의 타입을 number -> string으로 변경했습니다.
-> 카카오같이 `number`로 제공해주는 경우 `String`으로 타입 캐스팅하여 저장합니다.

# TODO
1. 소셜에서 email을 필수적으로 받도록 변경해야 합니다.