### PR TITLE
카카오 로그아웃과 네이버 로그아웃에서 호출되는 함수 분리

### DIFF
--- a/backend/src/auth/auth.kakao.controller.ts
+++ b/backend/src/auth/auth.kakao.controller.ts
@@ -30,7 +30,7 @@ export class AuthKakaoController {
   @Get('/logout')
   @UseGuards(JwtAuthGuard)
   async logout(@Res() res: Response, @User() user: UserSessionDto) {
-    await this.authService.logout(res, user);
+    await this.authService.logoutKakao(res, user);
     return res.redirect('/');
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,8 +40,8 @@ export class AuthService {
     return await this.authRepository.getUserDtoBySocialUserId(socialUserId, socialType);
   }
 
-  async logout(res: Response, user: UserSessionDto): Promise<void> {
-    this.logger.debug(`Called ${this.logout.name}`);
+  async logoutKakao(res: Response, user: UserSessionDto): Promise<void> {
+    this.logger.debug(`Called ${this.logoutKakao.name}`);
     const url = 'https://kapi.kakao.com/v1/user/logout';
     const headersRequest = {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -53,12 +53,17 @@ export class AuthService {
         .pipe(map((res) => res.data)),
       )
       .then((data) => {
-        console.log(data);
         res.clearCookie('populmap_token');
-        console.log('logout success!');
+        this.logger.log('logout success!');
       })
       .catch((err) => {
         throw err;
       });
+  }
+
+  async logout(res: Response, user: UserSessionDto): Promise<void> {
+    this.logger.debug(`Called ${this.logout.name}`);
+    res.clearCookie('populmap_token');
+    this.logger.log('logout success!');
   }
 }


### PR DESCRIPTION
## 카카오 로그아웃과 네이버 로그아웃에서 호출되는 함수 분리
카카오는 자체 로그아웃 API를 지원하지만, 네이버는 그렇지 않기 때문에 같은 로그아웃 함수로 처리하기가 힘듭니다.
따라서 관련 함수 자체를 분리하도록 수정하였습니다.