### PR TITLE
:sparkles: feat: Complete EventMarker Overlay modal

### DIFF
--- a/frontend/src/components/organisms/EventMarker.tsx
+++ b/frontend/src/components/organisms/EventMarker.tsx
@@ -25,12 +25,7 @@ const EventMarker = (props: EventMarkerProps): JSX.Element => {
         }}
       />
       {currentMarker === eventInfo.eventId && (
-        <EventSummaryOverlay
-          position={{
-            lat: eventInfo.lat,
-            lng: eventInfo.lng,
-          }}
-        />
+        <EventSummaryOverlay eventInfo={eventInfo} />
       )}
     </>
   );

--- a/frontend/src/components/organisms/EventSummaryOverlay.tsx
+++ b/frontend/src/components/organisms/EventSummaryOverlay.tsx
@@ -1,27 +1,34 @@
 import { CustomOverlayMap } from "react-kakao-maps-sdk";
+import { EventBasicInfoResponseDto } from "../../types/dto/EventBasicInfoResponse.dto";
 
 interface EventSummaryOverlayProps {
-  position: {
-    lat: number;
-    lng: number;
-  };
+  eventInfo: EventBasicInfoResponseDto;
 }
 
 const EventSummaryOverlay = (props: EventSummaryOverlayProps): JSX.Element => {
-  const { position } = props;
+  const { eventInfo } = props;
 
+  // navigate event Id
   const handleClick = (): void => {
-    console.log("clicked");
+    console.log("click");
   };
   return (
     <CustomOverlayMap
       position={{
-        lat: position.lat,
-        lng: position.lng,
+        lat: eventInfo.lat,
+        lng: eventInfo.lng,
       }}
+      clickable
     >
-      <div>
-        <span>1234</span>
+      <div
+        role="presentation"
+        onClick={(e): void => {
+          e.stopPropagation();
+        }}
+      >
+        <p>{eventInfo.title}</p>
+        <p>{eventInfo.address}</p>
+        <button onClick={handleClick}>자세히보기</button>
       </div>
     </CustomOverlayMap>
   );

--- a/frontend/src/components/organisms/LoadMap.tsx
+++ b/frontend/src/components/organisms/LoadMap.tsx
@@ -26,6 +26,9 @@ const LoadMap = (props: LoadMapProps): JSX.Element => {
         zIndex: "0",
       }}
       level={mapState.level}
+      onClick={(): void => {
+        setCurrentMarker(-1);
+      }}
     >
       {eventMarkers.map((eventInfo) => {
         return (


### PR DESCRIPTION
# ♻️ 변경 사항
- EventMarker 클릭 시  Overlay가 표시되고 해당 영역 내에서 Button이 올바르게 동작하도록 수정하였습니다. 
- Overlay 외 지역 클릭 시 Modal이 close되도록 수정하였습니다.

# ✏️ TODO
- 상세 페이지에서 사용할 EventId를 전역으로 관리하는 경우 LoadMap에 state로 사용하는 부분을 Redux slice로 빼서 사용
