### PR TITLE
:bug: fix: map level control

### DIFF
--- a/frontend/src/components/organisms/LoadMap.tsx
+++ b/frontend/src/components/organisms/LoadMap.tsx
@@ -1,7 +1,7 @@
 import { Map } from "react-kakao-maps-sdk";
 import { useEffect, useState } from "react";
 import { useAppSelector, useAppDispatch } from "../../redux/hook";
-import { mapLocationChange } from "../../redux/slices/mapSlice";
+import { mapLocationChange, mapLevelSelect } from "../../redux/slices/mapSlice";
 import { EventSummaryResponseDto } from "../../types/dto/EventSummaryResponse.dto";
 import EventMarker from "./EventMarker";
 
@@ -47,6 +47,9 @@ const LoadMap = (props: LoadMapProps): JSX.Element => {
       level={mapState.level}
       onClick={(): void => {
         setCurrentMarker(-1);
+      }}
+      onZoomChanged={(map): void => {
+        dispatch(mapLevelSelect(map.getLevel()));
       }}
     >
       {eventMarkers.map((eventInfo) => {

--- a/frontend/src/redux/slices/mapSlice.ts
+++ b/frontend/src/redux/slices/mapSlice.ts
@@ -34,7 +34,7 @@ export const mapSlice = createSlice({
       if (state.level > 1) state.level -= 1;
     },
     mapLevelDown: (state) => {
-      if (state.level < 12) state.level += 1;
+      if (state.level < 14) state.level += 1;
     },
     mapLevelSelect: (state, action: PayloadAction<number>) => {
       state.level = action.payload;
@@ -44,6 +44,7 @@ export const mapSlice = createSlice({
       action: PayloadAction<mapStateType["center"]>
     ) => {
       state.center = action.payload;
+      state.level = 3;
     },
     mapSearch: (state, action: PayloadAction<string>) => {
       state.search = action.payload;


### PR DESCRIPTION
# ♻️ 변경 사항
- 모바일, 터치 패드로 지도를 확대하거나 축소하는 경우에 map level에 반영이 되지 않았던 부분을 수정하였습니다.
- 검색 및 geolocation 사용 시 map level을 3으로 고정하여 보여주도록 수정하였습니다.