### PR TITLE
:sparkles: 임시 로그인 시, 202를 응답하도록 수정, /auth/password/assert API 추가

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Inject, Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Inject, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { IAuthRepository } from './repository/auth.repository.interface';
 import { v4 as uuid } from 'uuid';
 import { UserSessionDto } from 'src/dto/user.session.dto';
@@ -196,5 +196,23 @@ export class AuthService {
       .catch((err) => {
         throw err;
       });
+  }
+
+  async updateIsTemporary(userId: number, isTemporary: boolean): Promise<void> {
+    this.logger.debug(`Called ${this.updateIsTemporary.name}`);
+    await this.authRepository.updateIsTemporary(userId, isTemporary);
+  }
+
+  async getIsTemporary(userId: number): Promise<boolean> {
+    this.logger.debug(`Called ${this.getIsTemporary.name}`);
+    return await this.authRepository.getIsTemporary(userId);
+  }
+
+  async assertPassword(userId: number, password: string): Promise<void> {
+    this.logger.debug(`Called ${this.assertPassword.name}`);
+    const hashedPassword = await this.authRepository.getHashedPassword(userId);
+    if (!(await bcrypt.compare(password, hashedPassword))) {
+      throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
+    }
   }
 }

--- a/backend/src/auth/google/auth.google.controller.ts
+++ b/backend/src/auth/google/auth.google.controller.ts
@@ -53,7 +53,6 @@ export class AuthGoogleController {
     this.logger.debug(`Called ${this.loginCallback.name}`);
     try {
       await this.authService.socialRegister(user, res);
-      return res.redirect('/');
     } catch (err) {
       this.logger.error(err);
       if (err instanceof HttpException) {

--- a/backend/src/auth/kakao/auth.kakao.controller.ts
+++ b/backend/src/auth/kakao/auth.kakao.controller.ts
@@ -53,7 +53,6 @@ export class AuthKakaoController {
     this.logger.debug(`Called ${this.loginCallback.name}`);
     try {
       await this.authService.socialRegister(user, res);
-      return res.redirect('/');
     } catch (err) {
       this.logger.error(err);
       if (err instanceof HttpException) {

--- a/backend/src/auth/naver/auth.naver.controller.ts
+++ b/backend/src/auth/naver/auth.naver.controller.ts
@@ -53,7 +53,6 @@ export class AuthNaverController {
     this.logger.debug(`Called ${this.loginCallback.name}`);
     try {
       await this.authService.socialRegister(user, res);
-      return res.redirect('/');
     } catch (err) {
       this.logger.error(err);
       if (err instanceof HttpException) {

--- a/backend/src/auth/repository/auth.repository.interface.ts
+++ b/backend/src/auth/repository/auth.repository.interface.ts
@@ -79,4 +79,24 @@ export interface IAuthRepository {
    * @param userId
    */
   deleteUser(userId: number): Promise<void>;
+
+  /**
+   * userId에 해당하는 유저의 isTemporary를 변경한다.
+   * @param userId
+   */
+  updateIsTemporary(userId: number, isTemporary: boolean): Promise<void>;
+
+  /**
+   * userId에 해당하는 유저의 isTemporary를 가져온다
+   * @param userId
+   * @return isTemporary
+   */
+  getIsTemporary(userId: number): Promise<boolean>;
+
+  /**
+   * userId에 해당하는 유저의 hashed 비밀번호를 가져온다
+   * @param userId
+   * @return hashedPassword
+   */
+  getHashedPassword(userId: number): Promise<string>;
 }

--- a/backend/src/auth/repository/auth.repository.ts
+++ b/backend/src/auth/repository/auth.repository.ts
@@ -183,4 +183,41 @@ export class AuthRepository implements IAuthRepository {
       userId: userId,
     });
   }
+
+  async updateIsTemporary(userId: number, isTemporary: boolean): Promise<void> {
+    await this.authSiteRepository
+      .createQueryBuilder()
+      .update(AuthSite)
+      .set({
+        isTemporary: isTemporary,
+      })
+      .where({
+        siteUserId: userId,
+      })
+      .execute();
+  }
+
+  async getIsTemporary(userId: number): Promise<boolean> {
+    const result = await this.authSiteRepository.findOne({
+      select: {
+        isTemporary: true,
+      },
+      where: {
+        siteUserId: userId,
+      },
+    });
+    return result.isTemporary;
+  }
+
+  async getHashedPassword(userId: number): Promise<string> {
+    const result = await this.authSiteRepository.findOne({
+      select: {
+        password: true,
+      },
+      where: {
+        siteUserId: userId,
+      },
+    });
+    return result.password;
+  }
 }

--- a/backend/src/dto/request/password.body.request.dto.ts
+++ b/backend/src/dto/request/password.body.request.dto.ts
@@ -1,6 +1,11 @@
 import { IsString } from 'class-validator';
 
-export class PasswordBodyRequestDto {
+export class NewPasswordBodyRequestDto {
   @IsString()
   newPassword: string;
+}
+
+export class PasswordBodyRequestDto {
+  @IsString()
+  password: string;
 }

--- a/backend/src/entities/auth.site.entity.ts
+++ b/backend/src/entities/auth.site.entity.ts
@@ -39,6 +39,13 @@ export default class AuthSite {
   })
   lastLogin: Date;
 
+  @Column({
+    name: 'is_temporary',
+    type: 'boolean',
+    default: false,
+  })
+  isTemporary: boolean;
+
   @OneToOne(() => User)
   @JoinColumn({
     name: 'site_user_id',


### PR DESCRIPTION

# ✨ 추가 기능
- /auth/password/assert API 추가

# ♻️ 변경 사항
- 임시 비밀번호로 로그인 시, 202를 응답하도록 수정
- 로그인이나 회원가입 후 메인으로 리다이렉트되지 않도록 수정

# ✏️ TODO
- 이 작업 이후에 하실 내용이 있다면 작성해주세요!
