### PR TITLE
:sparkles: feat: Apply redux persist

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-ga": "^3.3.1",
         "react-kakao-maps-sdk": "^1.1.5",
         "react-router-dom": "^6.4.3",
+        "redux-persist": "^6.0.0",
         "typescript": "^4.6.4",
         "vite": "^3.2.4",
         "vite-plugin-html-env": "^1.2.7",
@@ -4407,6 +4408,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -8103,6 +8112,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react-ga": "^3.3.1",
     "react-kakao-maps-sdk": "^1.1.5",
     "react-router-dom": "^6.4.3",
+    "redux-persist": "^6.0.0",
     "typescript": "^4.6.4",
     "vite": "^3.2.4",
     "vite-plugin-html-env": "^1.2.7",

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,17 +3,23 @@ import ReactDOM from "react-dom/client";
 import { ThemeProvider } from "@mui/material/styles";
 import { Provider } from "react-redux";
 import { CookiesProvider } from "react-cookie";
+import { persistStore } from "redux-persist";
+import { PersistGate } from "redux-persist/integration/react";
 import muiCustomTheme from "./themes/muiCustomTheme";
 import store from "./redux/store";
 import App from "./App";
+
+const persistor = persistStore(store);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <CookiesProvider>
       <Provider store={store}>
-        <ThemeProvider theme={muiCustomTheme}>
-          <App />
-        </ThemeProvider>
+        <PersistGate loading={null} persistor={persistor}>
+          <ThemeProvider theme={muiCustomTheme}>
+            <App />
+          </ThemeProvider>
+        </PersistGate>
       </Provider>
     </CookiesProvider>
   </React.StrictMode>

--- a/frontend/src/redux/store.ts
+++ b/frontend/src/redux/store.ts
@@ -1,13 +1,23 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import { persistReducer } from "redux-persist";
+import storage from "redux-persist/lib/storage";
 import mapSlice from "./slices/mapSlice";
 import userSlice from "./slices/userSlice";
 
+const reducer = combineReducers({
+  map: mapSlice,
+  user: userSlice,
+});
+
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, reducer);
+
 const store = configureStore({
-  reducer: {
-    // reducerName: reducer
-    map: mapSlice,
-    user: userSlice,
-  },
+  reducer: persistedReducer,
 });
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION

# ✨ 추가 기능
- redux persist를 추가하여 redux에 저장된 값이 브라우저를 새로고침하는 경우에 날아가지 않도록 하였습니다. 
- 로그인 이후 유저의 정보를 redux에 저장하여 유저의 인증이 필요한 api에 적용하였습니다.