### PR TITLE
EventSummary 그룹핑

### DIFF
--- a/backend/src/dto/event.summary.dto.ts
+++ b/backend/src/dto/event.summary.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import ProgressType from 'src/enums/progress.type.enum';
 
-export class EventSummaryResponseDto {
+export class EventSummaryDto {
   @ApiProperty({
     description: '행사 고유 ID',
     example: 1,
@@ -19,18 +19,6 @@ export class EventSummaryResponseDto {
     example: '경기도 용인시 수지구 포은대로 499 수지레스피아',
   })
   address: string;
-
-  @ApiProperty({
-    description: '위도',
-    example: 37.323,
-  })
-  lat: number;
-
-  @ApiProperty({
-    description: '경도',
-    example: 127.099,
-  })
-  lng: number;
 
   @ApiProperty({
     description: '행사 진행 여부',

--- a/backend/src/dto/response/event.summary.group.response.dto.ts
+++ b/backend/src/dto/response/event.summary.group.response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EventSummaryDto } from '../event.summary.dto';
+import ProgressType from 'src/enums/progress.type.enum';
+
+export class EventSummaryGroupResponseDto {
+  @ApiProperty({
+    description: '이벤트 요약 정보',
+    example: [
+      {
+        eventId: 1,
+        title: '11월 토요키즈클래식',
+        address: '경기도 용인시 수지구 포은대로 499 수지레스피아',
+        progress: ProgressType.BEFOREPROGRESS,
+      },
+    ],
+  })
+  eventSummaries: EventSummaryDto[];
+
+  @ApiProperty({
+    description: '위도',
+    example: 37.321234,
+  })
+  lat: number;
+
+  @ApiProperty({
+    description: '경도',
+    example: 127.123456,
+  })
+  lng: number;
+}

--- a/backend/src/event/event.module.ts
+++ b/backend/src/event/event.module.ts
@@ -8,6 +8,7 @@ import { EventRepository } from './repository/event.repository';
 import { BookmarkRepository } from './repository/bookmark.repository';
 import EventDetail from 'src/entities/event.detail.entity';
 import { EventService } from './event.service';
+import { UtilsModule } from 'src/utils/utils.module';
 
 const repo1 = {
   provide: 'IEventRepository',
@@ -23,6 +24,7 @@ const repo2 = {
     TypeOrmModule.forFeature([Event, EventDetail, Bookmark]),
     forwardRef(() => EventBookmarkModule),
     forwardRef(() => EventSearchModule),
+    forwardRef(() => UtilsModule),
   ],
   providers: [EventService, repo1, repo2],
   controllers: [],

--- a/backend/src/event/repository/event.repository.interface.ts
+++ b/backend/src/event/repository/event.repository.interface.ts
@@ -1,6 +1,6 @@
 import { EventDetailResponseDto } from 'src/dto/response/event.detail.response.dto';
 import { EventPagiNationResponseDto } from 'src/dto/response/event.pagination.response.dto';
-import { EventSummaryResponseDto } from 'src/dto/response/event.summary.response.dto';
+import { EventSummaryGroupResponseDto } from 'src/dto/response/event.summary.group.response.dto';
 import CityType from 'src/enums/city.type.enum';
 import ProgressType from 'src/enums/progress.type.enum';
 
@@ -52,7 +52,7 @@ export interface IEventRepository {
   getEventSummary(
     city?: CityType,
     progress?: ProgressType,
-  ): Promise<EventSummaryResponseDto[]>;
+  ): Promise<EventSummaryGroupResponseDto[]>;
 
   /**
    * eventId에 해당하는 eventDetail 정보를 반환한다.

--- a/backend/src/event/repository/event.repository.ts
+++ b/backend/src/event/repository/event.repository.ts
@@ -6,7 +6,7 @@ import { Repository } from 'typeorm';
 import { IEventRepository } from './event.repository.interface';
 import ProgressType from 'src/enums/progress.type.enum';
 import CityType from 'src/enums/city.type.enum';
-import { EventSummaryResponseDto } from 'src/dto/response/event.summary.response.dto';
+import { EventSummaryGroupResponseDto } from 'src/dto/response/event.summary.group.response.dto';
 import { EventDetailResponseDto } from 'src/dto/response/event.detail.response.dto';
 import { EventPagiNationResponseDto } from 'src/dto/response/event.pagination.response.dto';
 
@@ -222,7 +222,7 @@ export class EventRepository implements IEventRepository {
   async getEventSummary(
     city?: CityType,
     progress?: ProgressType,
-  ): Promise<EventSummaryResponseDto[]> {
+  ): Promise<EventSummaryGroupResponseDto[]> {
     if (!city) {
       city = CityType.ALL;
     }

--- a/backend/src/event/search/event.search.controller.ts
+++ b/backend/src/event/search/event.search.controller.ts
@@ -20,7 +20,7 @@ import {
 import { EventSearchService } from './event.search.service';
 import CityType from 'src/enums/city.type.enum';
 import ProgressType from 'src/enums/progress.type.enum';
-import { EventSummaryResponseDto } from 'src/dto/response/event.summary.response.dto';
+import { EventSummaryGroupResponseDto } from 'src/dto/response/event.summary.group.response.dto';
 import { EventDetailResponseDto } from 'src/dto/response/event.detail.response.dto';
 import { EventPagiNationResponseDto } from 'src/dto/response/event.pagination.response.dto';
 
@@ -56,7 +56,7 @@ export class EventSearchController {
   async getEventSummary(
     @Query('city') city?: CityType,
     @Query('progress') progress?: ProgressType,
-  ): Promise<EventSummaryResponseDto[]> {
+  ): Promise<EventSummaryGroupResponseDto[]> {
     this.logger.debug(`Called ${this.getEventSummary.name}`);
     try {
       return await this.eventSearchService.getEventSummary(city, progress);

--- a/backend/src/event/search/event.search.service.ts
+++ b/backend/src/event/search/event.search.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { EventSummaryResponseDto } from 'src/dto/response/event.summary.response.dto';
+import { EventSummaryGroupResponseDto } from 'src/dto/response/event.summary.group.response.dto';
 import CityType from 'src/enums/city.type.enum';
 import ProgressType from 'src/enums/progress.type.enum';
 import { IEventRepository } from '../repository/event.repository.interface';
@@ -16,7 +16,7 @@ export class EventSearchService {
   async getEventSummary(
     city?: CityType,
     progress?: ProgressType,
-  ): Promise<EventSummaryResponseDto[]> {
+  ): Promise<EventSummaryGroupResponseDto[]> {
     this.logger.debug(`Called ${this.getEventSummary.name}`);
     try {
       return await this.eventRepository.getEventSummary(city, progress);

--- a/backend/src/utils/toolbox.component.ts
+++ b/backend/src/utils/toolbox.component.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class ToolBoxComponent {
-  groupBy(array: Array<any>, func: Function) {
+  groupBy(array: Array<any>, func: any) {
     let groups = {};
     array.forEach(function (obj) {
       const group = JSON.stringify(func(obj));

--- a/backend/src/utils/toolbox.component.ts
+++ b/backend/src/utils/toolbox.component.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ToolBoxComponent {
+  constructor() {}
+
+  groupBy(array: Array<any>, func: Function) {
+    let groups = {};
+    array.forEach(function (obj) {
+      const group = JSON.stringify(func(obj));
+      groups[group] = groups[group] || [];
+      groups[group].push(obj);
+    });
+    return Object.keys(groups).map(function (group) {
+      return groups[group];
+    });
+  }
+}

--- a/backend/src/utils/toolbox.component.ts
+++ b/backend/src/utils/toolbox.component.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class ToolBoxComponent {
-  constructor() {}
-
   groupBy(array: Array<any>, func: Function) {
     let groups = {};
     array.forEach(function (obj) {

--- a/backend/src/utils/utils.module.ts
+++ b/backend/src/utils/utils.module.ts
@@ -13,6 +13,7 @@ import { RealtimeCityDataComponent } from './realtime.city.data.component';
 import { CityModule } from 'src/city/city.module';
 import { EventInformationDataComponent } from './event.information.data.component';
 import { EventModule } from 'src/event/event.module';
+import { ToolBoxComponent } from './toolbox.component';
 
 @Module({
   imports: [
@@ -28,7 +29,7 @@ import { EventModule } from 'src/event/event.module';
     HttpModule,
     forwardRef(() => AuthModule),
     forwardRef(() => CityModule),
-    EventModule,
+    forwardRef(() => EventModule),
   ],
   controllers: [],
   providers: [
@@ -36,7 +37,8 @@ import { EventModule } from 'src/event/event.module';
     EmailSender,
     RealtimeCityDataComponent,
     EventInformationDataComponent,
+    ToolBoxComponent,
   ],
-  exports: [EmailSender, KakaoSearch],
+  exports: [EmailSender, KakaoSearch, ToolBoxComponent],
 })
 export class UtilsModule {}


### PR DESCRIPTION

# ✨ 추가 기능
- 새로 추가된 내용을 작성해주세요!

# ♻️ 변경 사항
- `EventSummary` 정보에서 위도, 경도가 일치하는 데이터는 같은 그룹으로 묶어서 응답하도록 수정했습니다.
- Response DTO 수정
```
export class EventSummaryDto {

  eventId: number;


  title: string;


  address: string;


  progress: ProgressType;
}

export class EventSummaryGroupResponseDto {
  eventSummaries: EventSummaryeDto[];
  lat: number;
  lng: number;
}

EventSummaryGroupResponseDto[];
```

# ✏️ TODO
- 이 작업 이후에 하실 내용이 있다면 작성해주세요!
