### PR TITLE
eventlist를 가져올 때 bookmark_id가 null인지 확인하도록 수정

### DIFF
--- a/backend/src/event/repository/event.repository.ts
+++ b/backend/src/event/repository/event.repository.ts
@@ -340,6 +340,7 @@ export class EventRepository implements IEventRepository {
         'ed.call as ed_call',
         'e.progress as e_progress',
         'u.userId as u_user_id',
+        'b.bookmarkId as b_bookmark_id',
         'COUNT(*) OVER () AS cnt',
       ])
       .leftJoin('e.bookmarks', 'b', 'b.bookmarkEventId = e.eventId')
@@ -365,7 +366,8 @@ export class EventRepository implements IEventRepository {
           endTime: result.ed_end_time,
           call: result.ed_call,
           progress: result.e_progress,
-          isBookmarked: result.u_user_id === userId ? true : false,
+          isBookmarked:
+            result.b_bookmark_id && result.u_user_id === userId ? true : false,
         } as EventListDto;
       }),
       totalLength: results.length > 0 ? Number(results[0].cnt) : 0,


### PR DESCRIPTION

# ✨ 추가 기능
- 새로 추가된 내용을 작성해주세요!

# ♻️ 변경 사항
- `eventlist`를 가져올 때 `bookmark_id`가 `null`인지 확인하도록 수정했습니다.
- 이제 북마크에 추가된 행사라면 `isBookmarked`가 `true`인 값 하나만 응답합니다!

# ✏️ TODO
- 이 작업 이후에 하실 내용이 있다면 작성해주세요!
