### PR TITLE
fix: OAuth login && Signup logic

### DIFF
--- a/frontend/src/components/atoms/buttons/LoginSumbitButton.tsx
+++ b/frontend/src/components/atoms/buttons/LoginSumbitButton.tsx
@@ -1,10 +1,6 @@
 import Button from "@mui/material/Button";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import jwtDecode from "jwt-decode";
-import { useAppDispatch } from "../../../redux/hook";
-import { userInfoUpdate } from "../../../redux/slices/userSlice";
-import { getCookie } from "../../../network/react-cookie/cookie";
 import { axiosAuthLogin } from "../../../network/axios/axios.auth";
 
 interface LoginSumbitButtonProps {
@@ -18,14 +14,11 @@ const LoginSumbitButton = (props: LoginSumbitButtonProps): JSX.Element => {
   const [isLoginFail, setIsLoginFail] = useState<boolean>(false);
 
   const navigate = useNavigate();
-  const dispatch = useAppDispatch();
 
   const handleClick = (): void => {
     axiosAuthLogin({ id, password })
       .then((response) => {
         if (response.status === 200) {
-          const token = getCookie("populmap_token");
-          dispatch(userInfoUpdate(jwtDecode(token)));
           navigate("/");
         } else if (response.status === 202) navigate("/changepassword");
       })

--- a/frontend/src/components/atoms/buttons/SignupSubmitButton.tsx
+++ b/frontend/src/components/atoms/buttons/SignupSubmitButton.tsx
@@ -20,7 +20,7 @@ const SignupSubmitButton = (props: SignupSubmitButtonProps): JSX.Element => {
       .then((response) => {
         if (response.status === 201) {
           alert("회원가입에 성공했습니다.");
-          navigate("/login");
+          navigate("/");
         }
       })
       .catch((error) => setIsSignupFail(true));

--- a/frontend/src/components/templates/MainTemplate.tsx
+++ b/frontend/src/components/templates/MainTemplate.tsx
@@ -17,6 +17,7 @@ import { CityAccidentResponseDto } from "../../types/dto/CityAccidentResponse.dt
 import { CityPeopleResponseDto } from "../../types/dto/CityPeopleResponse.dto";
 import { EventSummaryGroupResponseDto } from "../../types/dto/EventSummaryResponse.dto";
 import { useAppSelector } from "../../redux/hook";
+import useGetToken from "../../hooks/useGetToken";
 
 const MainSection = styled.section`
   position: relative;
@@ -51,6 +52,7 @@ const MainTemplate = (): JSX.Element => {
   const [city, setCity] = useState<string>("전국");
   const [progress, setProgress] = useState<string>("전체");
 
+  useGetToken();
   useEffect((): void => {
     axiosEventSearchSummary(city, progress)
       .then((response) => {

--- a/frontend/src/hooks/useGetToken.ts
+++ b/frontend/src/hooks/useGetToken.ts
@@ -1,0 +1,22 @@
+import { useNavigate } from "react-router-dom";
+import jwtDecode from "jwt-decode";
+import { useAppDispatch, useAppSelector } from "../redux/hook";
+import { userInfoUpdate } from "../redux/slices/userSlice";
+import { getCookie } from "../network/react-cookie/cookie";
+import { useEffect } from "react";
+
+const useGetToken = (): void => {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const user = useAppSelector((state) => state.user);
+
+  useEffect(() => {
+    const token = getCookie("populmap_token");
+    if (user.userId === -1 && token) {
+      dispatch(userInfoUpdate(jwtDecode(token)));
+      navigate("/");
+    }
+  }, []);
+};
+
+export default useGetToken;


### PR DESCRIPTION
# ♻️ 변경 사항
- useGetToken hook 추가
- 사이트 회원가입 성공 시 Login page로 이동하지 않고 main page로 보내 추가적으로 login을 하지 않도록 하였습니다.
- OAuth 로그인 시 token을 생성하고, main page로 redirect되면 token의 데이터를 저장할 수 있도록 하였습니다.

