### PR TITLE
fix: Template height property

### DIFF
--- a/frontend/src/components/templates/ContentTemplate.tsx
+++ b/frontend/src/components/templates/ContentTemplate.tsx
@@ -2,10 +2,8 @@ import styled from "@emotion/styled";
 import { PropsWithChildren } from "react";
 
 const ContentSection = styled.section`
-  height: 100vh;
-  width: 100vw;
-  max-width: 30rem;
-  max-height: 60rem;
+  max-width: 480px;
+  max-height: 960px;
   margin: 0 auto;
 `;
 

--- a/frontend/src/components/templates/HeaderTemplate.tsx
+++ b/frontend/src/components/templates/HeaderTemplate.tsx
@@ -4,11 +4,13 @@ import HeaderMenu from "../organisms/HeaderMenu";
 import { useNavigate } from "react-router-dom";
 
 const Header = styled.header`
-  width: 100%;
-  height: 2.5rem;
+  height: 5vh;
   display: flex;
   justify-content: space-between;
   touch-action: none;
+  button {
+    padding-top: 0.7rem;
+  }
 `;
 
 const HeaderTemplate = (): JSX.Element => {

--- a/frontend/src/components/templates/MainTemplate.tsx
+++ b/frontend/src/components/templates/MainTemplate.tsx
@@ -19,7 +19,7 @@ import { useAppSelector } from "../../redux/hook";
 import useGetToken from "../../hooks/useGetToken";
 
 const MainSectionStyle = styled.section`
-  height: 55rem;
+  height: 90vh;
   position: relative;
 `;
 

--- a/frontend/src/components/templates/SearchTemplate.tsx
+++ b/frontend/src/components/templates/SearchTemplate.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import SearchBar from "../organisms/SearchBar";
 
 const SearchSectionStyle = styled.section`
-  height: 2.5rem;
+  height: 5vh;
   touch-action: none;
 `;
 


### PR DESCRIPTION
# ♻️ 변경 사항
- ContentTemplate의 width, height를 고정 px로 설정
- MainTemplate의 height이 55rem으로 설정되어 스크롤이 생기는 현상을 수정하고, Header, SearchTemplate에 맞춰 height를 vh로 변경

